### PR TITLE
Revert "Update dependency vabene1111/recipes to v1.1.0"

### DIFF
--- a/firestrike/apps/tandoor_recipes/docker-compose.yml
+++ b/firestrike/apps/tandoor_recipes/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     entrypoint: /usr/local/bin/litestream replicate
 
   web_recipes:
-    image: vabene1111/recipes:1.1.0
+    image: vabene1111/recipes:1.0.8
     restart: always
     env_file:
       - ./.env


### PR DESCRIPTION
Reverts gloriousDan/HomeLab#12

Since sqlite doesn't work in v1.1.0 we need to stay in v1.0.8 until https://github.com/TandoorRecipes/recipes/issues/1614 is fixed.